### PR TITLE
@sandersonet A more generic edit contact view

### DIFF
--- a/dist/backbone/views/shared/edit_contact.coffee
+++ b/dist/backbone/views/shared/edit_contact.coffee
@@ -4,32 +4,29 @@ class App.Views.ContactEdit extends Backbone.View
     JST['dist/templates/edit_contact']
 
   events:
-    'click .finish': 'onEditFinish'
-    'click .select-user': 'onSelectUser'
+    'click .finish'             : 'onEditFinish'
+    'click .select-user'        : 'onSelectUser'
+    'click .begin-edit-contact' : 'onEditStart'
+    'keyup .contact-title'      : 'onTitleUpdate'
 
   defaults:
     idParam: 'approving_authority_id'
     titleParam: 'approving_authority_title'
     emailParam: 'approving_authority_email'
     nameParam: 'approving_authority_name'
-    editClassName: '.edit-approving-authority'
+    inputName: 'Approving Authority'
 
   initialize: (options) ->
-    { @idParam, @titleParam, @emailParam, @nameParam, @editClassName } = _.defaults options, @defaults()
+    { @idParam, @titleParam, @emailParam, @nameParam, @inputName } = _.defaults options, @defaults
     @contacts = App.current_organization_users
 
   render: ->
+    @setupState()
     @$el.html(@template()(@renderParams()))
     @$alert = @$('.alert').hide()
     @$errorMessage = @$('.error-message')
     @onEditStart()
-    @bindEvents()
-    @setupState()
     @
-
-  bindEvents: ->
-    @$("#{@editClassName}").click @onEditStart
-    @$("input[name=#{@titleParam}]").on 'keyup', @onTitleUpdate
 
   setupState: ->
     @state = new Backbone.Model(
@@ -40,13 +37,21 @@ class App.Views.ContactEdit extends Backbone.View
     @state.on "change:#{@emailParam}", @onEmailChange, @
 
   renderParams: ->
-    { contacts: @contacts, model: @state, helpers: App.Helpers }
+    {
+      helpers: App.Helpers
+      contacts: @contacts
+      contactName: @state.get(@nameParam)
+      contactTitle: @state.get(@titleParam)
+      contactEmail: @state.get(@emailParam)
+      contactId: @state.get(@idParam)
+      inputName: @inputName
+    }
 
   onNameChange: ->
-    @$('.contact-name').text(@state.get(@nameParam))
+    @$('.contact-name').text @state.get(@nameParam)
 
   onTitleChange: ->
-    @$('.contact-email').text(@state.get(@titleParam))
+    @$('.contact-email').text @state.get(@titleParam)
 
   onEmailChange: ->
     src = App.Helpers.gravatar_url @state.get(@emailParam), 48
@@ -54,7 +59,7 @@ class App.Views.ContactEdit extends Backbone.View
 
   onEditStart: ->
     @$el.addClass('editing')
-    titleValue = $.trim(@$('input[name="#{@titleParam}"]').val())
+    titleValue = $.trim @$('input.contact-title').val()
     @state.set @titleParam, titleValue
 
   onEditFinish: ->
@@ -63,8 +68,8 @@ class App.Views.ContactEdit extends Backbone.View
     else
       @showError 'Title is required'
 
-  onSelectUser: (e) =>
-    uid = $(e.target).data('user-id')
+  onSelectUser: (event) =>
+    uid = $(event.target).data('user-id')
     contact = @contacts.get(uid)
     @state.set @idParam, uid
     @state.set @nameParam, contact.get('name')
@@ -75,10 +80,9 @@ class App.Views.ContactEdit extends Backbone.View
     @$el.removeClass 'editing'
     @$alert.hide().removeClass 'animated fadeInLeft'
 
-  onTitleUpdate: (e) =>
-    if val = $(e.target).val()
-      $.trim $(e.target).val()
-      @state.set @titleParam, val
+  onTitleUpdate: (event) =>
+    val = $.trim $(event.target).val()
+    @state.set @titleParam, val
 
   showError: (message) ->
     @$errorMessage.text message

--- a/dist/templates/edit_contact.hamlc
+++ b/dist/templates/edit_contact.hamlc
@@ -1,18 +1,19 @@
 .edit-compliance-document-contact
   .panel.panel-default.micro-panel.compliance-document-contact
     %header
-      %h5 Approving Authority
-      %a.edit-contacts-link.edit-approving-authority Edit
+      %h5= @inputName
+      %a.edit-contacts-link.begin-edit-contact Edit
     .panel-body.contact
       .gravatar.sm
-        %img.contact-gravatar{ src: @helpers.gravatar_url(@model.get('approving_authority_email'), 48) }
+        - if @contactEmail
+          %img.contact-gravatar{ src: @helpers.gravatar_url(@contactEmail, 48) }
       .contact-info
-        .contact-name= @model.get('approving_authority_name')
-        .contact-email= @model.get('approving_authority_title')
+        .contact-name= @contactName
+        .contact-email= @contactTitle
 
   .edit-contact-panel.panel.panel-default.micro-panel
     %header
-      %h5 Approving Authority
+      %h5= @inputName
       %a.edit-contacts-link.finish.btn.btn-xs.btn-primary Ok
     .panel-body.contact
       .alert.alert-danger
@@ -20,7 +21,7 @@
         %span.error-message
       .btn-group.dropdown-select
         %a.btn.dropdown-toggle{ data: { toggle: 'dropdown' } }
-          %span.contact-name= @model.get('approving_authority_name')
+          %span.contact-name= @contactName
           %i.fa.fa-chevron-down
 
         %ul.dropdown-menu
@@ -28,4 +29,4 @@
             %li
               %a.select-user{ data: {  user_id: user.get('id') }}= user.get('name')
 
-      %input.form-control{ placeholder: 'Approving Authority Title', name: 'approving_authority_title', value: @model.get('approving_authority_title') }
+      %input.form-control.contact-title{ placeholder: "#{@inputName} Title", value: @contactTitle }


### PR DESCRIPTION
Working on a more generic implementation of the ContactEdit view. Currently the view requires a model to only have one contact and for that contact to have a very specific structure. I implemented defaults in such a way so that it should be backwards compatible. 

I also changed the methods to use the more standard camelCase instead of underscore naming conventions.

Let me know what you think before merging. I still need to do some more testing. 
