### PR TITLE
Use SET for doc approvals

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "aptible-sass",
-    "version": "1.3.10",
+    "version": "1.3.11",
     "authors": [
         "Chas Ballew <chas@aptible.com>",
         "Skylar Anderson <skylar@aptible.com>",

--- a/dist/templates/edit_contact.hamlc
+++ b/dist/templates/edit_contact.hamlc
@@ -14,7 +14,7 @@
   .edit-contact-panel.panel.panel-default.micro-panel
     %header
       %h5= @inputName
-      %a.edit-contacts-link.finish.btn.btn-xs.btn-primary Ok
+      %a.edit-contacts-link.finish.btn.btn-xs.btn-primary SET
     .panel-body.contact
       .alert.alert-danger
         %strong Error:


### PR DESCRIPTION
This is an intermediate fix to make it more obvious that the Approving Authority needs to be explicitly designated.
