### PR TITLE
Change z-index value none -> auto

### DIFF
--- a/dist/styles/aptible_nav.scss
+++ b/dist/styles/aptible_nav.scss
@@ -18,7 +18,7 @@ header.primary-nav-header {
   box-shadow: inset 0px -2px 5px 0px rgba(0,0,0,0.05);
   padding: 10px;
   margin: 0;
-  z-index: none;
+  z-index: auto;
 
   .nav.nav-pills {
     margin: 5px 0 5px -12px;


### PR DESCRIPTION
@sandersonet for you

This changes none to auto, fixing https://github.com/aptible/diesel.aptible.com/issues/67.
The value of `none` was ignored, causing it to inherit the `z-index: 1000`, which creates a new stacking context for the `.primary-nav-header` div. Changing to `auto` overrides the `z-index: 1000` and doesn't create a new stacking context, so it is stacked underneath the dropdown as it should be.

The real issue here may be that my HTML in diesel is bad — maybe the navbar class names are incorrect instead? If there are some changes to make there I'm happy to.

Before:
![developer tools - http 3a 2f 2flocalhost 3a4200 2fstacks 2f3 2fapps 2015-01-26 11-37-43](https://cloud.githubusercontent.com/assets/2023/5903535/3b2f1ba8-a550-11e4-96fe-e8c8f04f600d.png)

After:
![developer tools - http localhost 4200 stacks 3 apps 2015-01-26 11-44-35](https://cloud.githubusercontent.com/assets/2023/5903621/cf3045f2-a550-11e4-9b9d-71959878bdfa.jpg)
