### PR TITLE
Add styles for panel-steps

### DIFF
--- a/dist/styles/aptible_panels.scss
+++ b/dist/styles/aptible_panels.scss
@@ -334,3 +334,48 @@
     }
   }
 }
+
+.panel.panel-steps {
+  .panel-step {
+    background: $color-bg-light-gray;
+    border-bottom: 1px solid $color-bg-dark-gray;
+
+    &:last-child {
+      border-bottom: 0;
+    }
+  }
+
+  .panel-step-num {
+    background: $color-bg-light-gray;
+    width: 80px;
+    float: left;
+
+    i.fa {
+      font-size: 36px;
+      text-align: center;
+      margin: 30px 0 0;
+      width: 100%;
+    }
+
+    h3 {
+      color: $color-bright-blue;
+      font-size: 36px;
+      font-weight: $weight-semibold;
+      text-align: center;
+      margin-top: 30px;
+    }
+  }
+
+  .panel-step-info {
+    h3 {
+      font-size: 18px;
+      font-weight: $weight-semibold;
+      margin: 0 0 16px;
+    }
+
+    margin-left: 80px;
+    padding: 30px;
+    border-left: 1px solid $color-bg-light-gray;
+    background: white;
+  }
+}


### PR DESCRIPTION
@sandersonet for you

This adds some styling for panel-steps so that the checklist for an undeployed app looks right.
This pairs up with the work done for https://github.com/aptible/diesel.aptible.com/issues/78.

I tried to reuse existing variable names wherever possible, but I might have missed some around the typography or positioning/width.

With these style, the nondeployed app page looks like:

![image](https://cloud.githubusercontent.com/assets/2023/6235036/613b6eaa-b6ad-11e4-8995-1ab550df7f92.png)
