### PR TITLE
Remove unused compliance dashboard styles

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "aptible-sass",
-    "version": "1.3.23",
+    "version": "1.3.24",
     "authors": [
         "Chas Ballew <chas@aptible.com>",
         "Skylar Anderson <skylar@aptible.com>",

--- a/dist/styles/aptible_compliance.scss
+++ b/dist/styles/aptible_compliance.scss
@@ -39,56 +39,6 @@ $color-compliance-danger: #e36666;
   }
 }
 
-.compliance-status-panel {
-  .compliance-status {
-    text-align: center;
-    padding: 20px 0 10px;
-
-    &:hover {
-      ul.compliance-nav {
-        visibility: visible;
-      }
-    }
-  }
-
-  .compliance-document {
-    font-size: 14px;
-    font-weight: $weight-semibold;
-  }
-
-  .compliance-effective {
-    font-size: 12px;
-    color: $color-light;
-  }
-
-  .compliance-icon {
-    margin-bottom: 5px;
-  }
-
-  ul.compliance-nav {
-    text-align: center;
-    margin: 5px 0;
-    padding: 0;
-    visibility: hidden;
-
-    > li {
-      display: inline-block;
-      list-style-type: none;
-      float: none;
-
-      a {
-        font-size: 12px;
-        color: $color-light;
-        font-weight: $weight-semibold;
-      }
-
-      & + li {
-        margin-left: 12px;
-      }
-    }
-  }
-}
-
 .compliance-dashboard-list {
   margin-top: 10px;
 }


### PR DESCRIPTION
These styles aren't shared anywhere else, so I ported them over to just the compliance app and refreshed their styles in https://github.com/aptible/compliance.aptible.com/pull/55